### PR TITLE
Add consistent namespace to commands and configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,31 +44,31 @@
     "button"
   ],
   "activationEvents": [
-    "onCommand:extension.back",
-    "onCommand:extension.forward",
-    "onCommand:extension.switch",
-    "onCommand:extension.save",
-    "onCommand:extension.beautify",
-    "onCommand:extension.toggleWhitespace",
-    "onCommand:extension.filelist",
-    "onCommand:extension.toggleTerminal",
-    "onCommand:extension.toggleActivityBar",
-    "onCommand:extension.quickOpen",
-    "onCommand:extension.findReplace",
-    "onCommand:extension.undo",
-    "onCommand:extension.redo",
-    "onCommand:extension.commentLine",
-    "onCommand:extension.saveAll",
-    "onCommand:extension.formatWith",
-    "onCommand:extension.openFile",
-    "onCommand:extension.newFile",
-    "onCommand:extension.goToDefinition",
-    "onCommand:extension.cut",
-    "onCommand:extension.copy",
-    "onCommand:extension.paste",
-    "onCommand:extension.compareWithSaved",
-    "onCommand:extension.showCommands",
-    "onCommand:extension.startDebug"
+    "onCommand:ShortcutMenuBar.back",
+    "onCommand:ShortcutMenuBar.forward",
+    "onCommand:ShortcutMenuBar.switch",
+    "onCommand:ShortcutMenuBar.save",
+    "onCommand:ShortcutMenuBar.beautify",
+    "onCommand:ShortcutMenuBar.toggleWhitespace",
+    "onCommand:ShortcutMenuBar.filelist",
+    "onCommand:ShortcutMenuBar.toggleTerminal",
+    "onCommand:ShortcutMenuBar.toggleActivityBar",
+    "onCommand:ShortcutMenuBar.quickOpen",
+    "onCommand:ShortcutMenuBar.findReplace",
+    "onCommand:ShortcutMenuBar.undo",
+    "onCommand:ShortcutMenuBar.redo",
+    "onCommand:ShortcutMenuBar.commentLine",
+    "onCommand:ShortcutMenuBar.saveAll",
+    "onCommand:ShortcutMenuBar.formatWith",
+    "onCommand:ShortcutMenuBar.openFile",
+    "onCommand:ShortcutMenuBar.newFile",
+    "onCommand:ShortcutMenuBar.goToDefinition",
+    "onCommand:ShortcutMenuBar.cut",
+    "onCommand:ShortcutMenuBar.copy",
+    "onCommand:ShortcutMenuBar.paste",
+    "onCommand:ShortcutMenuBar.compareWithSaved",
+    "onCommand:ShortcutMenuBar.showCommands",
+    "onCommand:ShortcutMenuBar.startDebug"
   ],
   "main": "./out/extension",
   "contributes": {
@@ -77,126 +77,326 @@
         "title": "Shortcut Menu Bar configuration",
         "properties": {
           "Save active file": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.saveActiveFile instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Save file'"
+          },
+          "Navigate back": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.navigateBack instead.",
+            "type": "boolean",
+            "default": true,
+            "readOnly": true,
+            "description": "show icon for 'Nagivate back'"
+          },
+          "Navigate forward": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.navigateForward instead.",
+            "type": "boolean",
+            "default": true,
+            "readOnly": true,
+            "description": "show icon for 'Nagivate forward'"
+          },
+          "Switch header source": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.switchHeaderSource instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Switch header/source'"
+          },
+          "Beautify active file": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.beautifyActiveFile instead.",
+            "type": "boolean",
+            "default": true,
+            "readOnly": true,
+            "description": "show icon for 'Beautify/Format document'"
+          },
+          "Toggle render whitespace": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.toggleRenderWhitespace instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Toggle render whitespace'"
+          },
+          "Open files list": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.openFilesList instead.",
+            "type": "boolean",
+            "default": true,
+            "readOnly": true,
+            "description": "show icon for 'Open files list'"
+          },
+          "Toggle terminal": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.toggleTerminal instead.",
+            "type": "boolean",
+            "default": true,
+            "readOnly": true,
+            "description": "show icon for 'Toggle terminal'"
+          },
+          "Toggle activity bar": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.toggleActivityBar instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Toggle activity bar'"
+          },
+          "Quick open": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.quickOpen instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for Go to File, 'Quick Open'"
+          },
+          "Find replace": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.findReplace instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Find/Replace in active file'"
+          },
+          "Undo": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.undo instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Undo'"
+          },
+          "Redo": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.redo instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Redo'"
+          },
+          "Toggle line comment": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.toggleLineComment instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Toggle line comment'"
+          },
+          "Save all": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.saveAll instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Save all'"
+          },
+          "Format document with": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.formatDocumentWith instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Format document with...'"
+          },
+          "Open file": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.openFile instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Open File'"
+          },
+          "New file": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.newFile instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'New File'"
+          },
+          "Go to definition": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.goToDefinition instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Go to definition'"
+          },
+          "Cut": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.cut instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Cut'"
+          },
+          "Copy": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.copy instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Copy'"
+          },
+          "Paste": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.paste instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Paste'"
+          },
+          "Compare with saved": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.compareWithSaved instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Compare active file with saved'"
+          },
+          "Open command pallet": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.openCommandPallet instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Open command pallet / Show all commands'"
+          },
+          "Start debugging": {
+            "deprecationMessage": "Deprecated! Use ShortcutMenuBar.startDebugging instead.",
+            "type": "boolean",
+            "default": false,
+            "readOnly": true,
+            "description": "show icon for 'Start debugging'"
+          },
+          "ShortcutMenuBar.saveActiveFile": {
+            "title": "Save active file",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Save file'"
           },
-          "Navigate back": {
+          "ShortcutMenuBar.navigateBack": {
+            "title": "Navigate back",
             "type": "boolean",
             "default": true,
             "description": "show icon for 'Nagivate back'"
           },
-          "Navigate forward": {
+          "ShortcutMenuBar.navigateForward": {
+            "title": "Navigate forward",
             "type": "boolean",
             "default": true,
             "description": "show icon for 'Nagivate forward'"
           },
-          "Switch header source": {
+          "ShortcutMenuBar.switchHeaderSource": {
+            "title": "Switch header source",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Switch header/source'"
           },
-          "Beautify active file": {
+          "ShortcutMenuBar.beautifyActiveFile": {
+            "title": "Beautify active file",
             "type": "boolean",
             "default": true,
             "description": "show icon for 'Beautify/Format document'"
           },
-          "Toggle render whitespace": {
+          "ShortcutMenuBar.toggleRenderWhitespace": {
+            "title": "Toggle render whitespace",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Toggle render whitespace'"
           },
-          "Open files list": {
+          "ShortcutMenuBar.openFilesList": {
+            "title": "Open files list",
             "type": "boolean",
             "default": true,
             "description": "show icon for 'Open files list'"
           },
-          "Toggle terminal": {
+          "ShortcutMenuBar.toggleTerminal": {
+            "title": "Toggle terminal",
             "type": "boolean",
             "default": true,
             "description": "show icon for 'Toggle terminal'"
           },
-          "Toggle activity bar": {
+          "ShortcutMenuBar.toggleActivityBar": {
+            "title": "Toggle activity bar",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Toggle activity bar'"
           },
-          "Quick open": {
+          "ShortcutMenuBar.quickOpen": {
+            "title": "Quick open",
             "type": "boolean",
             "default": false,
             "description": "show icon for Go to File, 'Quick Open'"
           },
-          "Find replace": {
+          "ShortcutMenuBar.findReplace": {
+            "title": "Find replace",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Find/Replace in active file'"
           },
-          "Undo": {
+          "ShortcutMenuBar.Undo": {
+            "title": "Undo",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Undo'"
           },
-          "Redo": {
+          "ShortcutMenuBar.Redo": {
+            "title": "Redo",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Redo'"
           },
-          "Toggle line comment": {
+          "ShortcutMenuBar.toggleLineComment": {
+            "title": "Toggle line comment",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Toggle line comment'"
           },
-          "Save all": {
+          "ShortcutMenuBar.saveAll": {
+            "title": "Save all",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Save all'"
           },
-          "Format document with": {
+          "ShortcutMenuBar.formatDocumentWith": {
+            "title": "Format document with",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Format document with...'"
           },
-          "Open file": {
+          "ShortcutMenuBar.openFile": {
+            "title": "Open file",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Open File'"
           },
-          "New file": {
+          "ShortcutMenuBar.newFile": {
+            "title": "New file",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'New File'"
           },
-          "Go to definition": {
+          "ShortcutMenuBar.goToDefinition": {
+            "title": "Go to definition",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Go to definition'"
           },
-          "Cut": {
+          "ShortcutMenuBar.cut": {
+            "title": "Cut",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Cut'"
           },
-          "Copy": {
+          "ShortcutMenuBar.copy": {
+            "title": "Copy",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Copy'"
           },
-          "Paste": {
+          "ShortcutMenuBar.paste": {
+            "title": "Paste",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Paste'"
           },
-          "Compare with saved": {
+          "ShortcutMenuBar.compareWithSaved": {
+            "title": "Compare with saved",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Compare active file with saved'"
           },
-          "Open command pallet": {
+          "ShortcutMenuBar.openCommandPallet": {
+            "title": "Open command pallet",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Open command pallet / Show all commands'"
           },
-          "Start debugging": {
+          "ShortcutMenuBar.startDebugging": {
+            "title": "Start debugging",
             "type": "boolean",
             "default": false,
             "description": "show icon for 'Start debugging'"
@@ -206,225 +406,225 @@
     ],
     "commands": [
       {
-        "command": "extension.back",
+        "command": "ShortcutMenuBar.back",
         "title": "Navigate Back",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/triangle-left_light.svg",
           "dark": "images/triangle-left.svg"
         }
       },
       {
-        "command": "extension.forward",
+        "command": "ShortcutMenuBar.forward",
         "title": "Navigate Forward",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/triangle-right_light.svg",
           "dark": "images/triangle-right.svg"
         }
       },
       {
-        "command": "extension.switch",
+        "command": "ShortcutMenuBar.switch",
         "title": "Switch Header/Source",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/switch_light.svg",
           "dark": "images/switch.svg"
         }
       },
       {
-        "command": "extension.save",
+        "command": "ShortcutMenuBar.save",
         "title": "Save",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/save_light.svg",
           "dark": "images/save.svg"
         }
       },
       {
-        "command": "extension.beautify",
+        "command": "ShortcutMenuBar.beautify",
         "title": "Beautify",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/format_light.svg",
           "dark": "images/format.svg"
         }
       },
       {
-        "command": "extension.toggleWhitespace",
+        "command": "ShortcutMenuBar.toggleWhitespace",
         "title": "Toggle Render Whitespace",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/whitespace_light.svg",
           "dark": "images/whitespace.svg"
         }
       },
       {
-        "command": "extension.filelist",
+        "command": "ShortcutMenuBar.filelist",
         "title": "Opened Files",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/list_light.svg",
           "dark": "images/list.svg"
         }
       },
       {
-        "command": "extension.toggleTerminal",
+        "command": "ShortcutMenuBar.toggleTerminal",
         "title": "Toggle terminal",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/terminal_light.svg",
           "dark": "images/terminal.svg"
         }
       },
       {
-        "command": "extension.toggleActivityBar",
+        "command": "ShortcutMenuBar.toggleActivityBar",
         "title": "Toggle activity bar",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/activitybar_light.svg",
           "dark": "images/activitybar.svg"
         }
       },
       {
-        "command": "extension.quickOpen",
+        "command": "ShortcutMenuBar.quickOpen",
         "title": "Quick open",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/files-search_light.svg",
           "dark": "images/files-search.svg"
         }
       },
       {
-        "command": "extension.findReplace",
+        "command": "ShortcutMenuBar.findReplace",
         "title": "Find Replace",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/find_light.svg",
           "dark": "images/find.svg"
         }
       },
       {
-        "command": "extension.undo",
+        "command": "ShortcutMenuBar.undo",
         "title": "Undo",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/undo_light.svg",
           "dark": "images/undo.svg"
         }
       },
       {
-        "command": "extension.redo",
+        "command": "ShortcutMenuBar.redo",
         "title": "Redo",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/redo_light.svg",
           "dark": "images/redo.svg"
         }
       },
       {
-        "command": "extension.commentLine",
+        "command": "ShortcutMenuBar.commentLine",
         "title": "Toggle line comment",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/commentLine_light.svg",
           "dark": "images/commentLine.svg"
         }
       },
       {
-        "command": "extension.saveAll",
+        "command": "ShortcutMenuBar.saveAll",
         "title": "Save all",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/saveAll_light.svg",
           "dark": "images/saveAll.svg"
         }
       },
       {
-        "command": "extension.formatWith",
+        "command": "ShortcutMenuBar.formatWith",
         "title": "Format document with..",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/formatWith_light.svg",
           "dark": "images/formatWith.svg"
         }
       },
       {
-        "command": "extension.openFile",
+        "command": "ShortcutMenuBar.openFile",
         "title": "Open file",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/openFile_light.svg",
           "dark": "images/openFile.svg"
         }
       },
       {
-        "command": "extension.newFile",
+        "command": "ShortcutMenuBar.newFile",
         "title": "New file",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/newFile_light.svg",
           "dark": "images/newFile.svg"
         }
       },
       {
-        "command": "extension.goToDefinition",
+        "command": "ShortcutMenuBar.goToDefinition",
         "title": "Go to definition",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/goToDefinition_light.svg",
           "dark": "images/goToDefinition.svg"
         }
       },
       {
-        "command": "extension.cut",
+        "command": "ShortcutMenuBar.cut",
         "title": "Cut",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/cut_light.svg",
           "dark": "images/cut.svg"
         }
       },
       {
-        "command": "extension.copy",
+        "command": "ShortcutMenuBar.copy",
         "title": "Copy",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/copy_light.svg",
           "dark": "images/copy.svg"
         }
       },
       {
-        "command": "extension.paste",
+        "command": "ShortcutMenuBar.paste",
         "title": "Paste",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/paste_light.svg",
           "dark": "images/paste.svg"
         }
       },
       {
-        "command": "extension.compareWithSaved",
+        "command": "ShortcutMenuBar.compareWithSaved",
         "title": "Compare with saved",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/compareWithSaved_light.svg",
           "dark": "images/compareWithSaved.svg"
         }
       },
       {
-        "command": "extension.showCommands",
+        "command": "ShortcutMenuBar.showCommands",
         "title": "Open command pallet",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/commands_light.svg",
           "dark": "images/commands.svg"
         }
       },
       {
-        "command": "extension.startDebug",
+        "command": "ShortcutMenuBar.startDebug",
         "title": "Start debugging",
-        "category": "menubar",
+        "category": "ShortcutMenuBar",
         "icon": {
           "light": "images/debug_light.svg",
           "dark": "images/debug.svg"
@@ -434,128 +634,128 @@
     "menus": {
       "editor/title": [
         {
-          "when": "config.Navigate back",
-          "command": "extension.back",
+          "when": "config.ShortcutMenuBar.navigateBack",
+          "command": "ShortcutMenuBar.back",
           "group": "navigation@1"
         },
         {
-          "when": "config.Navigate forward",
-          "command": "extension.forward",
+          "when": "config.Navigate forward || config.ShortcutMenuBar.navigateForward",
+          "command": "ShortcutMenuBar.forward",
           "group": "navigation@2"
         },
         {
-          "when": "editorTextFocus && config.Switch header source",
-          "command": "extension.switch",
+          "when": "editorTextFocus && (config.Switch header source || config.ShortcutMenuBar.switchHeaderSource",
+          "command": "ShortcutMenuBar.switch",
           "group": "navigation@3"
         },
         {
-          "when": "!isInDiffEditor && !markdownPreviewFocus && config.Save active file",
-          "command": "extension.save",
+          "when": "!isInDiffEditor && !markdownPreviewFocus && (config.Save active file || config.ShortcutMenuBar.saveActiveFile)",
+          "command": "ShortcutMenuBar.save",
           "group": "navigation@4"
         },
         {
-          "when": "!isInDiffEditor && !markdownPreviewFocus && config.Beautify active file",
-          "command": "extension.beautify",
+          "when": "!isInDiffEditor && !markdownPreviewFocus && (config.Beautify active file || config.ShortcutMenuBar.beautifyActiveFile)",
+          "command": "ShortcutMenuBar.beautify",
           "group": "navigation@5"
         },
         {
-          "when": "config.Toggle render whitespace",
-          "command": "extension.toggleWhitespace",
+          "when": "config.Toggle render whitespace || config.ShortcutMenuBar.toggleRenderWhiteSpace",
+          "command": "ShortcutMenuBar.toggleWhitespace",
           "group": "navigation@6"
         },
         {
-          "when": "!isInDiffEditor && !markdownPreviewFocus && config.Open files list",
-          "command": "extension.filelist",
+          "when": "!isInDiffEditor && !markdownPreviewFocus && (config.Open files list || config.ShortcutMenuBar.openFilesList)",
+          "command": "ShortcutMenuBar.filelist",
           "group": "navigation@7"
         },
         {
-          "when": "config.Toggle terminal",
-          "command": "extension.toggleTerminal",
+          "when": "config.Toggle terminal || config.ShortcutMenuBar.toggleTerminal",
+          "command": "ShortcutMenuBar.toggleTerminal",
           "group": "navigation@8"
         },
         {
-          "when": "config.Toggle activity bar",
-          "command": "extension.toggleActivityBar",
+          "when": "config.Toggle activity bar || config.ShortcutMenuBar.toggleActivity",
+          "command": "ShortcutMenuBar.toggleActivityBar",
           "group": "navigation@9"
         },
         {
-          "when": "config.Quick open",
-          "command": "extension.quickOpen",
+          "when": "config.Quick open || config.ShortcutMenuBar.quickOpen",
+          "command": "ShortcutMenuBar.quickOpen",
           "group": "navigation@10"
         },
         {
-          "when": "config.Find replace",
-          "command": "extension.findReplace",
+          "when": "config.Find replace || config.ShortcutMenuBar.findReplace",
+          "command": "ShortcutMenuBar.findReplace",
           "group": "navigation@11"
         },
         {
-          "when": "textInputFocus && !editorReadonly && config.Undo",
-          "command": "extension.undo",
+          "when": "textInputFocus && !editorReadonly && (config.Undo || config.ShortcutMenuBar.undo)",
+          "command": "ShortcutMenuBar.undo",
           "group": "navigation@12"
         },
         {
-          "when": "textInputFocus && !editorReadonly && config.Redo",
-          "command": "extension.redo",
+          "when": "textInputFocus && !editorReadonly && (config.Redo || config.ShortcutMenuBar.redo)",
+          "command": "ShortcutMenuBar.redo",
           "group": "navigation@13"
         },
         {
-          "when": "editorTextFocus && !editorReadonly && config.Toggle line comment",
-          "command": "extension.commentLine",
+          "when": "editorTextFocus && !editorReadonly && (config.Toggle line comment || config.ShortcutMenuBar.toggleLineComment)",
+          "command": "ShortcutMenuBar.commentLine",
           "group": "navigation@14"
         },
         {
-          "when": "config.Save all",
-          "command": "extension.saveAll",
+          "when": "config.Save all || config.ShortcutMenuBar.saveAll",
+          "command": "ShortcutMenuBar.saveAll",
           "group": "navigation@15"
         },
         {
-          "when": "!isInDiffEditor && !markdownPreviewFocus && config.Format document with",
-          "command": "extension.formatWith",
+          "when": "!isInDiffEditor && !markdownPreviewFocus && (config.Format document with || config.ShortcutMenuBar.formatDocumentWith)",
+          "command": "ShortcutMenuBar.formatWith",
           "group": "navigation@16"
         },
         {
-          "when": "config.Open file",
-          "command": "extension.openFile",
+          "when": "config.Open file || config.ShortcutMenuBar.openFile",
+          "command": "ShortcutMenuBar.openFile",
           "group": "navigation@17"
         },
         {
-          "when": "config.New file",
-          "command": "extension.newFile",
+          "when": "config.New file || config.ShortcutMenuBar.newFile",
+          "command": "ShortcutMenuBar.newFile",
           "group": "navigation@18"
         },
         {
-          "when": "config.Go to definition && editorHasDefinitionProvider && editorTextFocus && !isInEmbeddedEditor",
-          "command": "extension.goToDefinition",
+          "when": "(config.Go to definition || config.ShortcutMenuBar.goToDefinition) && editorHasDefinitionProvider && editorTextFocus && !isInEmbeddedEditor",
+          "command": "ShortcutMenuBar.goToDefinition",
           "group": "navigation@19"
         },
         {
-          "when": "config.Cut",
-          "command": "extension.cut",
+          "when": "config.Cut || config.ShortcutMenuBar.cut",
+          "command": "ShortcutMenuBar.cut",
           "group": "navigation@20"
         },
         {
-          "when": "config.Copy",
-          "command": "extension.copy",
+          "when": "config.Copy || config.ShortcutMenuBar.copy",
+          "command": "ShortcutMenuBar.copy",
           "group": "navigation@21"
         },
         {
-          "when": "config.Paste",
-          "command": "extension.paste",
+          "when": "config.Paste || config.ShortcutMenuBar.paste",
+          "command": "ShortcutMenuBar.paste",
           "group": "navigation@22"
         },
         {
-          "when": "config.Compare with saved",
-          "command": "extension.compareWithSaved",
+          "when": "config.Compare with saved || config.ShortcutMenuBar.compareWithSaved",
+          "command": "ShortcutMenuBar.compareWithSaved",
           "group": "navigation@23"
         },
         {
-          "when": "config.Open command pallet",
-          "command": "extension.showCommands",
+          "when": "config.Open command pallet || config.ShortcutMenuBar.openCommandPallet",
+          "command": "ShortcutMenuBar.showCommands",
           "group": "navigation@24"
         },
         {
-          "when": "config.Start debugging && debuggersAvailable && !inDebugMode",
-          "command": "extension.startDebug",
+          "when": "(config.Start debugging || config.ShortcutMenuBar.startDebugging) && debuggersAvailable && !inDebugMode",
+          "command": "ShortcutMenuBar.startDebug",
           "group": "navigation@25"
         }
       ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,30 +28,30 @@ export function activate(context: ExtensionContext) {
   let commandArray = [
     //=> ["name in package.json" , "name of command to execute"]
 
-    ["extension.save", "workbench.action.files.save"],
-    ["extension.toggleTerminal", "workbench.action.terminal.toggleTerminal"],
+    ["ShortcutMenuBar.save", "workbench.action.files.save"],
+    ["ShortcutMenuBar.toggleTerminal", "workbench.action.terminal.toggleTerminal"],
     [
-      "extension.toggleActivityBar",
+      "ShortcutMenuBar.toggleActivityBar",
       "workbench.action.toggleActivityBarVisibility",
     ],
-    ["extension.back", "workbench.action.navigateBack"],
-    ["extension.forward", "workbench.action.navigateForward"],
-    ["extension.toggleWhitespace", "editor.action.toggleRenderWhitespace"],
-    ["extension.quickOpen", "workbench.action.quickOpen"],
-    ["extension.findReplace", "editor.action.startFindReplaceAction"],
-    ["extension.undo", "undo"],
-    ["extension.redo", "redo"],
-    ["extension.commentLine", "editor.action.commentLine"],
-    ["extension.saveAll", "workbench.action.files.saveAll"],
-    ["extension.openFile", "workbench.action.files.openFile"],
-    ["extension.newFile", "workbench.action.files.newUntitledFile"],
-    ["extension.goToDefinition", "editor.action.revealDefinition"],
-    ["extension.cut", "editor.action.clipboardCutAction"],
-    ["extension.copy", "editor.action.clipboardCopyAction"],
-    ["extension.paste", "editor.action.clipboardPasteAction"],
-    ["extension.compareWithSaved", "workbench.files.action.compareWithSaved"],
-    ["extension.showCommands", "workbench.action.showCommands"],
-    ["extension.startDebug", "workbench.action.debug.start"],
+    ["ShortcutMenuBar.back", "workbench.action.navigateBack"],
+    ["ShortcutMenuBar.forward", "workbench.action.navigateForward"],
+    ["ShortcutMenuBar.toggleWhitespace", "editor.action.toggleRenderWhitespace"],
+    ["ShortcutMenuBar.quickOpen", "workbench.action.quickOpen"],
+    ["ShortcutMenuBar.findReplace", "editor.action.startFindReplaceAction"],
+    ["ShortcutMenuBar.undo", "undo"],
+    ["ShortcutMenuBar.redo", "redo"],
+    ["ShortcutMenuBar.commentLine", "editor.action.commentLine"],
+    ["ShortcutMenuBar.saveAll", "workbench.action.files.saveAll"],
+    ["ShortcutMenuBar.openFile", "workbench.action.files.openFile"],
+    ["ShortcutMenuBar.newFile", "workbench.action.files.newUntitledFile"],
+    ["ShortcutMenuBar.goToDefinition", "editor.action.revealDefinition"],
+    ["ShortcutMenuBar.cut", "editor.action.clipboardCutAction"],
+    ["ShortcutMenuBar.copy", "editor.action.clipboardCopyAction"],
+    ["ShortcutMenuBar.paste", "editor.action.clipboardPasteAction"],
+    ["ShortcutMenuBar.compareWithSaved", "workbench.files.action.compareWithSaved"],
+    ["ShortcutMenuBar.showCommands", "workbench.action.showCommands"],
+    ["ShortcutMenuBar.startDebug", "workbench.action.debug.start"],
   ];
 
   let disposableCommandsArray: Disposable[] = [];
@@ -62,7 +62,7 @@ export function activate(context: ExtensionContext) {
   commandArray.forEach((command) => {
     disposableCommandsArray.push(
       commands.registerCommand(command[0], () => {
-        commands.executeCommand(command[1]).then(function () {});
+        commands.executeCommand(command[1]).then(function () { });
       })
     );
   });
@@ -70,7 +70,7 @@ export function activate(context: ExtensionContext) {
   // Step: else add complex command separately
 
   let disposableBeautify = commands.registerCommand(
-    "extension.beautify",
+    "ShortcutMenuBar.beautify",
     () => {
       let editor = window.activeTextEditor;
       if (!editor) {
@@ -80,17 +80,17 @@ export function activate(context: ExtensionContext) {
       if (window.state.focused === true && !editor.selection.isEmpty) {
         commands
           .executeCommand("editor.action.formatSelection")
-          .then(function () {});
+          .then(function () { });
       } else {
         commands
           .executeCommand("editor.action.formatDocument")
-          .then(function () {});
+          .then(function () { });
       }
     }
   );
 
   let disposableFormatWith = commands.registerCommand(
-    "extension.formatWith",
+    "ShortcutMenuBar.formatWith",
     () => {
       let editor = window.activeTextEditor;
       if (!editor) {
@@ -100,18 +100,18 @@ export function activate(context: ExtensionContext) {
       if (window.state.focused === true && !editor.selection.isEmpty) {
         commands
           .executeCommand("editor.action.formatSelection.multiple")
-          .then(function () {});
+          .then(function () { });
       } else {
         commands
           .executeCommand("editor.action.formatDocument.multiple")
-          .then(function () {});
+          .then(function () { });
       }
     }
   );
 
   // see opened files list
   let disposableFileList = commands.registerCommand(
-    "extension.filelist",
+    "ShortcutMenuBar.filelist",
     () => {
       let editor = window.activeTextEditor;
       if (!editor || !editor.viewColumn) {
@@ -119,13 +119,13 @@ export function activate(context: ExtensionContext) {
       }
       commands
         .executeCommand("workbench.action.showAllEditorsByMostRecentlyUsed")
-        .then(function () {});
+        .then(function () { });
     }
   );
 
-  let disposableSwitch = commands.registerCommand("extension.switch", () => {
+  let disposableSwitch = commands.registerCommand("ShortcutMenuBar.switch", () => {
     if (hasCpp) {
-      commands.executeCommand("C_Cpp.SwitchHeaderSource").then(function () {});
+      commands.executeCommand("C_Cpp.SwitchHeaderSource").then(function () { });
     } else {
       window.showErrorMessage(
         "C/C++ extension (ms-vscode.cpptools) is not installed!"
@@ -150,4 +150,4 @@ export function activate(context: ExtensionContext) {
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() {}
+export function deactivate() { }


### PR DESCRIPTION
Hi Gourav!

I made this PR to illustrate how you could add an extension namespace to the configurations and commands your extension exports (as I have suggested in [this issue](https://github.com/GorvGoyl/Shortcut-Menu-Bar-VSCode-Extension/issues/29)) The configurations and commands would be more inline with how VS Code internally and also other extensions do these things. This breaks existing configs in the long run, though.

Regards,
Benni