### PR TITLE
include SPDX license identfier

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "engines": {
     "vscode": "^1.52.0"
   },
-  "license": "SEE license IN LICENSE file",
+  "license": "GPL-3.0-or-later",
   "icon": "images/menubar.png",
   "galleryBanner": {
     "color": "#752d00",


### PR DESCRIPTION
according to NPM docs and LICENSE, fixing npm warnings

If you, for some reasons don't want "or later" the SPDX identifier would be "GPL-3.0-only". And as the code has no single reference to the actual license the correct SPDX identifier is even more important then otherwise.
extension.ts should have the license note in, if you agree I PR that, too.